### PR TITLE
Add "despeck ocr" command

### DIFF
--- a/OCR.md
+++ b/OCR.md
@@ -1,0 +1,36 @@
+# OCR with Despeck
+
+To make OCR work, you need to install the following tools:
+
+* Tesseract (version 3.x)
+* ImageMagick (version 6.x)
+
+## Installation
+
+### MacOS
+
+To install tesseract itself:
+
+```sh
+$ brew install tesseract --all-languages
+$ brew install imagemagick
+```
+
+Or you can install tesseract with some languages manually:
+
+```sh
+$ brew install tesseract wget imagemagick
+$ mkdir -p ~/Downloads/tessdata
+$ cd ~/Downloads/tessdata
+$ wget https://github.com/tesseract-ocr/tessdata/raw/3.04.00/chi_sim.traineddata
+```
+
+The full list of languages trained data can be found here (note, they're different for different Tesseract versions):
+
+https://github.com/tesseract-ocr/tesseract/wiki/Data-Files#data-files-for-version-304305
+
+### Ubuntu/Debian
+
+```sh
+$ apt-get install tesseract-ocr tesseract-ocr-chi-sim imagemagick
+```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ gem 'despeck'
 
 and then run `bundle install`
 
+## OCR
+
+To be able to extract text via `despeck ocr` command, you'll need to install:
+
+* Tesseract (3.x)
+* ImageMagick (6.x)
+* Desired languages
+
+Installation instruction can be found here: [OCR tools installation guide](./OCR.md)
+
 ## Usage (Command Line)
 
 Getting actual help:

--- a/despeck.gemspec
+++ b/despeck.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'clamp', '~> 1.2'
   spec.add_dependency 'pdf-reader', '~> 2.1'
   spec.add_dependency 'prawn', '~> 2.2'
+  spec.add_dependency 'rmagick', '~> 2'
+  spec.add_dependency 'rtesseract', '~> 2.2'
   spec.add_dependency 'ruby-vips', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.16'

--- a/lib/commands/ocr.rb
+++ b/lib/commands/ocr.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Despeck
+  module Commands
+    # Subcommand that removes watermarks from images & PDFs
+    class Ocr < Clamp::Command
+      parameter 'input_file', 'Input file - either PDF or image',
+                attribute_name: :input_file
+      option ['-l', '--lang'],
+             'LANGUAGE',
+             'One of supported Tesseract languages (`eng` by default)',
+             default: :eng
+
+      def execute
+        puts Despeck::Ocr.new(input_file).text(lang: lang)
+      end
+    end
+  end
+end

--- a/lib/despeck.rb
+++ b/lib/despeck.rb
@@ -6,8 +6,11 @@ require 'pdf-reader'
 require 'prawn'
 require 'pry'
 require 'vips'
+require 'rmagick'
+require 'rtesseract'
 
 require_relative 'commands/remove'
+require_relative 'commands/ocr'
 
 require_relative 'despeck/logger'
 require_relative 'despeck/dominant_color'
@@ -16,6 +19,7 @@ require_relative 'despeck/watermark_mask'
 require_relative 'despeck/colour_checker'
 require_relative 'despeck/watermark_remover'
 require_relative 'despeck/pdf_tools'
+require_relative 'despeck/ocr'
 require_relative 'despeck/cli'
 
 # Prawn helper method are needed to calculate proper pages size

--- a/lib/despeck/cli.rb
+++ b/lib/despeck/cli.rb
@@ -9,5 +9,6 @@ module Despeck
     end
 
     subcommand('remove', 'Remove watermark', Despeck::Commands::Remove)
+    subcommand('ocr', 'Extract text from the image', Despeck::Commands::Ocr)
   end
 end

--- a/lib/despeck/ocr.rb
+++ b/lib/despeck/ocr.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Despeck
+  # Extracts text of desired language from the image
+  class Ocr
+    attr_reader :lang, :image_path
+
+    def initialize(image)
+      @image_path = image
+    end
+
+    def text(lang: :eng)
+      RTesseract.new(image_path, lang: lang).to_s
+    end
+  end
+end

--- a/lib/despeck/version.rb
+++ b/lib/despeck/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Despeck
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
# Usage

```sh
$ bundle exec despeck -l chi_sim spec/tmp/green_watermark.jpg

GM/T 0009__2012

5. 2 SM2 公钥
SM2公钥是 SM2 曲线上的一个点，由横坐标和纵坐标两个分量来表示，记为(x，y〉，简记为 Q，每

6 数据转换

在SM2算法的使用中将涉及8位字节串〈Octet String)和位串(Bit String〉之间的转换，主要包括
以下四种形式。

6.1 位串到8位宇节串的转换

位串长度若不是8的整数倍，需先在它的左边补O，以保证它的长度为8的倍数，然后构造8位字
节串，转换过程如下=

槽人=一个长度为 blen 的位串 B。

槽出=一个长度为 mlen 的字节串 M，其中 mlen 的取值为〈出en十7〉/8 的整数部分。

动作=将位串B=BoB1…B=【。-]转换到8位字节串M=MoM】'-'Mm=。。-]采用如下方法=

从 O<=<mlen一1，设 菅 =

M= = Bbkn_ 8- 8(mlen一 ] 一 =) Bb】cn- 7“ 8(m】en_ ] _餐) " ' Bblen-1一 8〈mkn一 ] 一 i)

对于 Mo ，量左边 8-blen%8 位设薹为 0，右边设量为 BOB】 。"B=一=。l。。+bl。n一l 。

输出 M。 ` ′

6.2 8位字节串到位串的转换

8位字节串到位串转换过程如下=

输人=一个长度为 mlen的8位字节串 M。

输出=一个长度为 blen=〈8暮mlen)的位串 B。

动作=将8位字节串 M=MoM]…M咖_]转换到位串 B=BoB]"-B。】。。_]采用如下方法=
从 ()<7二<l'【llet'l_"1，`设荸芦 =B8趸B8趸+1...B8…+7 = M艺

输出 B。

6.3 整数到8位字节串的转换

一个整数转换为8位字节串，基本方法是将其先使用二进制表达，然后把结果位串再转换为8位字

节串。 以下是转换流程=

槽人=一个非负整数 x,期望的8位字节串长度 mlen。 基本限制为=
28(m【en) 〉 x

槽出=一个长度为 mlen的8位字节串 M。

动作=将基于28=256的x值x=xm愉_]28(m愉一”十xml。。_=28(…】=”一2〉十…十x]28十xo 转换为一个8位
字节串 M=MoMl'-'Mm_。n一l采用如下方法=

从 O<乞<mlen_ 1 ，设置 = M。 = xml。。一]一=

输出 M。

6.4 8位字节串到薹数的转换

可以简单地把8位字节串看成以 256 为基表示的整数，转换过程如下=

输人=一个长度 mlen的8位字节串 Mo
2

 

   

```

# OCR with Despeck

To make OCR work, you need to install the following tools:

* Tesseract (version 3.x)
* ImageMagick (version 6.x)

## Installation

### MacOS

To install tesseract itself:

```sh
$ brew install tesseract --all-languages
$ brew install imagemagick
```

Or you can install tesseract with some languages manually:

```sh
$ brew install tesseract wget imagemagick
$ mkdir -p ~/Downloads/tessdata
$ cd ~/Downloads/tessdata
$ wget https://github.com/tesseract-ocr/tessdata/raw/3.04.00/chi_sim.traineddata
```

The full list of languages trained data can be found here (note, they're different for different Tesseract versions):

https://github.com/tesseract-ocr/tesseract/wiki/Data-Files#data-files-for-version-304305

### Ubuntu/Debian

```sh
$ apt-get install tesseract-ocr tesseract-ocr-chi-sim imagemagick
```
