### PR TITLE
Fixing mismatch number of bands When use Accurate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: false
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-    - VIPS_VERSION_MAJOR=8
-    - VIPS_VERSION_MINOR=5
-    - VIPS_VERSION_MICRO=7
+    - LIBVIPS_VERSION=8.7.4
     - PATH=$HOME/vips/bin:$PATH
     - LD_LIBRARY_PATH=$HOME/vips/lib:$LD_LIBRARY_PATH
     - PKG_CONFIG_PATH=$HOME/vips/lib/pkgconfig:$PKG_CONFIG_PATH

--- a/despeck.gemspec
+++ b/despeck.gemspec
@@ -24,18 +24,16 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'clamp', '~> 1.2'
   spec.add_dependency 'pdf-reader', '~> 2.1'
-  spec.add_dependency 'prawn', '~> 2.2'
+  spec.add_dependency 'prawn', '~> 2.2.0'
   spec.add_dependency 'rmagick', '~> 2'
   spec.add_dependency 'rtesseract', '~> 2.2'
   spec.add_dependency 'ruby-vips', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
-  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.81.0'

--- a/install-vips.sh
+++ b/install-vips.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 vips_site=https://github.com/jcupitt/libvips/releases/download
-version=$VIPS_VERSION_MAJOR.$VIPS_VERSION_MINOR.$VIPS_VERSION_MICRO
+version=$LIBVIPS_VERSION
 
 set -e
 
@@ -9,18 +9,23 @@ set -e
 # we could check the configure params as well I guess
 if [ -d "$HOME/vips/bin" ]; then
   installed_version=$($HOME/vips/bin/vips --version)
-  escaped_version="$VIPS_VERSION_MAJOR\.$VIPS_VERSION_MINOR\.$VIPS_VERSION_MICRO"
   echo "Need vips-$version"
   echo "Found $installed_version"
-  if [[ "$installed_version" =~ ^vips-$escaped_version ]]; then
+  if [[ "$installed_version" =~ ^vips-$version ]]; then
     echo "Using cached directory"
     exit 0
   fi
 fi
 
 rm -rf $HOME/vips
-wget $vips_site/v$version/vips-$version.tar.gz
+echo 'Downloading libvips source'
+wget $vips_site/v$version/vips-$version.tar.gz >/dev/null 2>&1
+echo 'Extracting'
 tar xf vips-$version.tar.gz
 cd vips-$version
-CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 ./configure --prefix=$HOME/vips $*
-make && make install
+echo 'Configuring'
+CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 ./configure --prefix=$HOME/vips $* >/dev/null 2>&1
+echo 'Make'
+make >/dev/null 2>&1
+echo 'Install'
+make install >/dev/null 2>&1

--- a/lib/despeck/watermark_remover.rb
+++ b/lib/despeck/watermark_remover.rb
@@ -63,7 +63,7 @@ module Despeck
       output_image = grayscale_algorithm(image, wm_color)
       output_image = increase_contrast(output_image) if add_contrast
       output_image = apply_black_improvement(output_image)
-      output_image = apply_grey_to_black(output_image) if wm_color != 'FF0000'
+      output_image = apply_grey_to_black(output_image)
       output_image
     end
 

--- a/spec/lib/dominant_color_v2_spec.rb
+++ b/spec/lib/dominant_color_v2_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Despeck::DominantColorV2 do
     let(:image) { read_image('purple_watermark.jpg') }
 
     it 'returns RGB of purple colour' do
-      expect(subject).to eq [185, 157, 183]
+      expect(subject).to eq [185, 157, 184]
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe Despeck::DominantColorV2 do
     let(:image) { read_image('blue_watermark.jpg') }
 
     it 'returns RGB of blue colour' do
-      expect(subject).to eq [169, 198, 224]
+      expect(subject).to eq [169, 198, 225]
     end
   end
 
@@ -47,7 +47,7 @@ RSpec.describe Despeck::DominantColorV2 do
     let(:image) { read_image('green_watermark.jpg') }
 
     it 'returns RGB of green colour' do
-      expect(subject).to eq [172, 205, 172]
+      expect(subject).to eq [171, 204, 171]
     end
   end
 

--- a/spec/lib/watermark_remover_spec.rb
+++ b/spec/lib/watermark_remover_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Despeck::WatermarkRemover do
 
       it_behaves_like 'watermark remover'
     end
-   end
+  end
 
   context 'for image without watermark' do
     let(:input_image) { read_image('bw.jpg') }

--- a/spec/lib/watermark_remover_spec.rb
+++ b/spec/lib/watermark_remover_spec.rb
@@ -3,12 +3,14 @@
 RSpec.describe Despeck::WatermarkRemover do
   let(:add_contrast)    { false }
   let(:add_black)       { false }
+  let(:accurate)        { false }
   let(:watermark_color) { nil }
   let(:output_image) do
     described_class.new(
       add_contrast: add_contrast,
       add_black: add_black,
-      watermark_color: watermark_color
+      watermark_color: watermark_color,
+      accurate: accurate
     ).remove_watermark(input_image)
   end
 
@@ -46,6 +48,33 @@ RSpec.describe Despeck::WatermarkRemover do
 
     it_behaves_like 'watermark remover'
   end
+
+  context 'when accurate flag given' do
+    let(:accurate) { true }
+    context 'for red watermark' do
+      let(:input_image) { read_image('red_watermark.jpg') }
+
+      it_behaves_like 'watermark remover'
+    end
+
+    context 'for green watermark' do
+      let(:input_image) { read_image('green_watermark.jpg') }
+
+      it_behaves_like 'watermark remover'
+    end
+
+    context 'for purple watermark' do
+      let(:input_image) { read_image('purple_watermark.jpg') }
+
+      it_behaves_like 'watermark remover'
+    end
+
+    context 'for yellow watermark' do
+      let(:input_image) { read_image('yellow_watermark.jpg') }
+
+      it_behaves_like 'watermark remover'
+    end
+   end
 
   context 'for image without watermark' do
     let(:input_image) { read_image('bw.jpg') }


### PR DESCRIPTION
Fixing #19.
by forcing `apply_grey_to_black` when removing the watermark, and make the `__remove_watermark__` function always return with a consistent number of bands