### PR TITLE
Add libvips 8.10.1 to Test matrix

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ '2.6', '2.5', '2.4' ]
-        libvips_version: ['8.6.5', '8.7.4']
+        libvips_version: ['8.6.5', '8.7.4', '8.10.1']
         experimental: [false]
         include:
           - ruby: '2.7'
@@ -56,8 +56,7 @@ jobs:
         export PATH=$HOME/vips/bin:$PATH
         export LD_LIBRARY_PATH=$HOME/vips/lib:$LD_LIBRARY_PATH
         export PKG_CONFIG_PATH=$HOME/vips/lib/pkgconfig:$PKG_CONFIG_PATH
-        gem uninstall bundler
-        gem install bundler -v '~> 1.16'
+        gem install bundler -v '~> 1.16' --default
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         cat Gemfile.lock

--- a/lib/despeck/installation_post_message.rb
+++ b/lib/despeck/installation_post_message.rb
@@ -37,7 +37,7 @@ module Despeck
       version_only = Vips.version_string.match(/(\d+\.\d+\.\d+)/)[0]
 
       min_version = '8.6.5'
-      return true if version_only > min_version
+      return true if Gem::Version.new(version_only) > Gem::Version.new(min_version)
 
       notes << <<~DOC
         - Your libvips version must be newer than version #{min_version}.


### PR DESCRIPTION
add libvips version 8.10.1 on the ci matrix. confirmed there is no breaking change from the latest libvips version for APIs that used by despeck

Resolves #36 